### PR TITLE
Not to override DNSReplyCode from DNSServer.h

### DIFF
--- a/examples/AsyncDNSServer/AsyncDNSServer.ino
+++ b/examples/AsyncDNSServer/AsyncDNSServer.ino
@@ -18,8 +18,8 @@ void setup() {
   // set which return code will be used for all other domains (e.g. sending
   // ServerFailure instead of NonExistentDomain will reduce number of queries
   // sent by clients)
-  // default is DNSReplyCode::NonExistentDomain
-  dnsServer.setErrorReplyCode(DNSReplyCode::ServerFailure);
+  // default is AsyncDNSReplyCode::NonExistentDomain
+  dnsServer.setErrorReplyCode(AsyncDNSReplyCode::ServerFailure);
 
   // start DNS server for a specific domain name
   dnsServer.start(DNS_PORT, "www.example.com", apIP);

--- a/examples/asyncDNServerFull/asyncDNServerFull.ino
+++ b/examples/asyncDNServerFull/asyncDNServerFull.ino
@@ -30,8 +30,8 @@ void setup() {
   // set which return code will be used for all other domains (e.g. sending
   // ServerFailure instead of NonExistentDomain will reduce number of queries
   // sent by clients)
-  // default is DNSReplyCode::NonExistentDomain
-  dnsServer.setErrorReplyCode(DNSReplyCode::ServerFailure);
+  // default is AsyncDNSReplyCode::NonExistentDomain
+  dnsServer.setErrorReplyCode(AsyncDNSReplyCode::ServerFailure);
 
   // start DNS server for a specific domain name
   dnsServer.start(DNS_PORT, "*", apIP);

--- a/src/ESPAsyncDNSServer.cpp
+++ b/src/ESPAsyncDNSServer.cpp
@@ -89,7 +89,7 @@ getDomainNameWithoutWwwPrefix(unsigned char *start)
 AsyncDNSServer::AsyncDNSServer()
 {
   _ttl = htonl(60);
-  _errorReplyCode = DNSReplyCode::NonExistentDomain;
+  _errorReplyCode = AsyncDNSReplyCode::NonExistentDomain;
 }
 
 bool 
@@ -117,7 +117,7 @@ AsyncDNSServer::start(const uint16_t port, const String &domainName,
 }
 
 void 
-AsyncDNSServer::setErrorReplyCode(const DNSReplyCode &replyCode)
+AsyncDNSServer::setErrorReplyCode(const AsyncDNSReplyCode &replyCode)
 {
   _errorReplyCode = replyCode;
 }
@@ -216,7 +216,7 @@ AsyncDNSServer::replyWithCustomCode(AsyncUDPPacket &packet)
   DNSHeader * _dnsHeader = (DNSHeader *)msg.data();
 
   _dnsHeader->QR = DNS_QR_RESPONSE;
-  _dnsHeader->RCode = (unsigned char)_errorReplyCode; //default is DNSReplyCode::NonExistentDomain
+  _dnsHeader->RCode = (unsigned char)_errorReplyCode; //default is AsyncDNSReplyCode::NonExistentDomain
   _dnsHeader->QDCount = 0;
 
   packet.send(msg);

--- a/src/ESPAsyncDNSServer.h
+++ b/src/ESPAsyncDNSServer.h
@@ -7,7 +7,7 @@
 #define DNS_QR_RESPONSE 1
 #define DNS_OPCODE_QUERY 0
 
-enum class DNSReplyCode : unsigned char
+enum class AsyncDNSReplyCode : unsigned char
 {
   NoError = 0,
   FormError = 1,
@@ -24,7 +24,7 @@ class AsyncDNSServer
 {
   public:
     AsyncDNSServer();
-    void setErrorReplyCode(const DNSReplyCode &replyCode);
+    void setErrorReplyCode(const AsyncDNSReplyCode &replyCode);
     void setTTL(const uint32_t ttl);
 
     // Returns true if successful, false if there are no sockets available
@@ -40,7 +40,7 @@ class AsyncDNSServer
     String _domainName;
     unsigned char _resolvedIP[4];
     uint32_t _ttl;
-    DNSReplyCode _errorReplyCode;
+    AsyncDNSReplyCode _errorReplyCode;
 
     void processRequest(AsyncUDPPacket &packet);
     void replyWithIP(AsyncUDPPacket &packet);


### PR DESCRIPTION
* replaced DNSReplyCode with AsyncDNSReplyCode so that this does not
interfere with DNSReplyCode in DNSServer.h. Sometimes users include both
libraries and this prevents compilation errors.

Dont know if this is the most elegant solution, but does the trick.