### PR TITLE
Update version for PlatformIO + Arduino

### DIFF
--- a/library.json
+++ b/library.json
@@ -15,7 +15,7 @@
   "version": "1.0.1",
   "license": "LGPL-3.0",
   "frameworks": "arduino",
-  "platforms": ["espressif8266", "espressif32"]
+  "platforms": ["espressif8266", "espressif32"],
   "examples": [
     "examples/*/*.ino"
   ]

--- a/library.json
+++ b/library.json
@@ -12,10 +12,10 @@
     "type": "git",
     "url": "https://github.com/devyte/ESPAsyncDNSServer.git"
   },
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "LGPL-3.0",
   "frameworks": "arduino",
-  "platforms":"espressif",
+  "platforms": ["espressif8266", "espressif32"]
   "examples": [
     "examples/*/*.ino"
   ]

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ESP AsyncDNSServer
-version=1.0.0
+version=1.0.1
 author=devyte
 maintainer=devyte
 sentence=Async DNS Server Library for ESP


### PR DESCRIPTION
Updates versions and fixes `platforms` array to correctly reflect ESP8266 **and** ESP32 support. (`espressif` is an extremely old way of writing `espressif8266` in PlatformIO). 

See [docs](https://docs.platformio.org/en/latest/manifests/library-json/fields/platforms.html) and [code](https://github.com/platformio/platformio-core/blob/029e66cd06a5048d53cea8cde2f2d949be063b44/platformio/package/manifest/parser.py#L365-L370).

After that version update a manual PIO registry can be triggered if needed..